### PR TITLE
Fix v1beta2 typos

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -47,12 +47,12 @@ var mappedAPIs = map[string]string{
 	"apiVersion: apps/v1beta2\nkind: DaemonSet":               "apiVersion: apps/v1\nkind: DaemonSet",
 	"apiVersion: extensions/v1beta1\nkind: Deployment":        "apiVersion: apps/v1\nkind: Deployment",
 	"apiVersion: apps/v1beta1\nkind: Deployment":              "apiVersion: apps/v1\nkind: Deployment",
-	"apiVersion: apps/v1beta12\nkind: Deployment":             "apiVersion: apps/v1\nkind: Deployment",
+	"apiVersion: apps/v1beta2\nkind: Deployment":              "apiVersion: apps/v1\nkind: Deployment",
 	"apiVersion: apps/v1beta1\nkind: StatefulSet":             "apiVersion: apps/v1\nkind: StatefulSet",
-	"apiVersion: apps/v1beta12\nkind: StatefulSet":            "apiVersion: apps/v1\nkind: StatefulSet",
+	"apiVersion: apps/v1beta2\nkind: StatefulSet":             "apiVersion: apps/v1\nkind: StatefulSet",
 	"apiVersion: extensions/v1beta1\nkind: ReplicaSet":        "apiVersion: apps/v1\nkind: ReplicaSet",
 	"apiVersion: apps/v1beta1\nkind: ReplicaSet":              "apiVersion: apps/v1\nkind: ReplicaSet",
-	"apiVersion: apps/v1beta12\nkind: ReplicaSet":             "apiVersion: apps/v1\nkind: ReplicaSet",
+	"apiVersion: apps/v1beta2\nkind: ReplicaSet":              "apiVersion: apps/v1\nkind: ReplicaSet",
 	"apiVersion: extensions/v1beta1\nkind: Ingress":           "apiVersion: networking.k8s.io/v1beta1\nkind: Ingress"}
 
 // ReplaceManifestUnSupportedAPIs returns a release manifest with deprecated or removed


### PR DESCRIPTION
I kept running into issues upgrading a chart without this patch. 

Output before:
```
2020/04/17 14:22:40 Found deprecated or removed Kubernetes API:
"apiVersion: extensions/v1beta1
kind: Ingress"
Supported API equivalent:
"apiVersion: networking.k8s.io/v1beta1
kind: Ingress"
```

Output after:
```
2020/04/17 14:56:49 Found deprecated or removed Kubernetes API:
"apiVersion: extensions/v1beta1
kind: Ingress"
Supported API equivalent:
"apiVersion: networking.k8s.io/v1beta1
kind: Ingress"
2020/04/17 14:56:49 Found deprecated or removed Kubernetes API:
"apiVersion: apps/v1beta2
kind: Deployment"
Supported API equivalent:
"apiVersion: apps/v1
kind: Deployment"
```