### PR TITLE
Fix deprecation for ingress

### DIFF
--- a/config/Map.yaml
+++ b/config/Map.yaml
@@ -54,7 +54,7 @@ mappings:
   - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: Ingress"
     newAPI: "apiVersion: networking.k8s.io/v1beta1\nkind: Ingress"
     deprecatedInVersion: "1.14"
-    removedInVersion: "1.16"
+    removedInVersion: "1.22"
 
   # Do NOT enable this prior to Kubernetes v1.17
   # - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: ClusterRole"


### PR DESCRIPTION
According to https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ ingresses with apiVersion `extensions/v1beta1` won't be removed until Kubernetes v1.22