### PR TITLE
Add missing apiVersion prefix in default mapping file

### DIFF
--- a/config/Map.yaml
+++ b/config/Map.yaml
@@ -39,7 +39,7 @@ mappings:
     newAPI: "apiVersion: apps/v1\nkind: ReplicaSet"
     deprecatedInVersion: "1.09"
     removedInVersion: "1.16"
-  - deprecatedAPI: "extensions/v1beta1\nkind: NetworkPolicy"
+  - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: NetworkPolicy"
     newAPI: "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy"
     deprecatedInVersion: "1.08"
     removedInVersion: "1.16"


### PR DESCRIPTION
This PR fixes a small issue in the default mapping file. The `apiVersion:` prefix is missing from the `extensions/v1beta1` `NetworkPolicy` mapping resulting in manifests that look like:

```
---
# Source: path/to/networkpolicy.yaml
apiVersion: apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  labels:
```

Subsequent helm upgrades then fail with:

```
Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: error parsing : error converting YAML to JSON: yaml: line 3: mapping values are not allowed in this context
```

because `apiVersion: apiVersion: networking.k8s.io/v1` is not valid YAML.