### PR TITLE
Print help when no arguments are passed

### DIFF
--- a/cmd/mapkubeapis/map.go
+++ b/cmd/mapkubeapis/map.go
@@ -54,7 +54,7 @@ func newMapCmd(out io.Writer, args []string) *cobra.Command {
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				cmd.Help()
-				os.Exit(0)
+				os.Exit(1)
 			} else if len(args) > 1 {
 				return errors.New("only one release name may be passed at a time")
 			}

--- a/cmd/mapkubeapis/map.go
+++ b/cmd/mapkubeapis/map.go
@@ -56,7 +56,7 @@ func newMapCmd(out io.Writer, args []string) *cobra.Command {
 				cmd.Help()
 				os.Exit(0)
 			} else if len(args) > 1 {
-				return errors.New("Only one release name may be passed at a time")
+				return errors.New("only one release name may be passed at a time")
 			}
 			return nil
 		},

--- a/cmd/mapkubeapis/map.go
+++ b/cmd/mapkubeapis/map.go
@@ -52,8 +52,11 @@ func newMapCmd(out io.Writer, args []string) *cobra.Command {
 		Long:         "Map release deprecated or removed Kubernetes APIs in-place",
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("name of release to be mapped needs to be passed")
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(0)
+			} else if len(args) > 1 {
+				return errors.New("Only one release name may be passed at a time")
 			}
 			return nil
 		},


### PR DESCRIPTION
This fixes #24 and also prints an error when more than one argument is passed to maintain the original behavior.